### PR TITLE
Windows port

### DIFF
--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -4,7 +4,12 @@
 //! Represent the physical address space of a virtual machine, which is composed
 //! by address ranges for memory and memory-mapped IO areas.
 
+#[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+
+#[cfg(windows)]
+use mmap_windows::{AsRawFd, RawFd};
+
 use std::sync::{Arc, Mutex};
 
 use guest_address::GuestAddress;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,12 @@ data_init_type!(i32);
 data_init_type!(i64);
 data_init_type!(isize);
 
+#[cfg(unix)]
+mod mmap_unix;
+
+#[cfg(windows)]
+mod mmap_windows;
+
 mod address_space;
 mod guest_address;
 mod guest_memory;

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -10,8 +10,19 @@
 
 use libc::c_void;
 pub use libc::MAP_FAILED;
-pub use std::os::unix::io::AsRawFd as AsRawFd;
+use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
+
+pub type RawFile = std::os::unix::io::RawFd;
+pub trait AsRawFile {
+    fn as_raw_file(&self) -> RawFile;
+}
+
+impl AsRawFile for std::fs::File {
+    fn as_raw_file(&self) -> RawFile {
+        self.as_raw_fd()
+    }
+}
 
 pub unsafe fn map_anon_mem(size: usize) -> *mut c_void {
     return libc::mmap(
@@ -24,13 +35,13 @@ pub unsafe fn map_anon_mem(size: usize) -> *mut c_void {
     );
 }
 
-pub unsafe fn map_shared_mem(file: &AsRawFd, size: usize, offset: usize) -> *mut c_void {
+pub unsafe fn map_shared_mem(file: &AsRawFile, size: usize, offset: usize) -> *mut c_void {
     return libc::mmap(
         null_mut(),
         size,
         libc::PROT_READ | libc::PROT_WRITE,
         libc::MAP_SHARED,
-        file.as_raw_fd(),
+        file.as_raw_file(),
         offset as libc::off_t,
     );
 }

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -1,0 +1,46 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+//
+//! The mmap_unix module provides internal unix specific abstractions
+//! for the mmap module.
+
+use libc::c_void;
+pub use libc::MAP_FAILED;
+pub use std::os::unix::io::AsRawFd as AsRawFd;
+use std::ptr::null_mut;
+
+pub unsafe fn map_anon_mem(size: usize) -> *mut c_void {
+    return libc::mmap(
+        null_mut(),
+        size,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
+        -1,
+        0,
+    );
+}
+
+pub unsafe fn map_shared_mem(file: &AsRawFd, size: usize, offset: usize) -> *mut c_void {
+    return libc::mmap(
+        null_mut(),
+        size,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_SHARED,
+        file.as_raw_fd(),
+        offset as libc::off_t,
+    );
+}
+
+pub unsafe fn unmap_mem(addr: *mut c_void, size: usize) -> i32 {
+    // madvising away the region is the same as the guest changing it.
+    // Next time it is read, it may return zero pages.
+    return libc::madvise(addr, size, libc::MADV_REMOVE);
+}
+
+pub unsafe fn release_mem(addr: *mut c_void, size: usize) {
+    libc::munmap(addr, size);
+}

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -1,0 +1,108 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+//
+//! The mmap_windows module provides internal windows specific abstractions
+//! for the mmap module.
+//! 
+use libc::{c_void, size_t};
+use std;
+use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::ptr::null;
+
+#[allow(non_snake_case)]
+#[link(name = "kernel32")]
+extern "stdcall" {
+    pub fn VirtualAlloc(
+        lpAddress: *mut c_void,
+        dwSize: size_t,
+        flAllocationType: u32,
+        flProtect: u32,
+    ) -> *mut c_void;
+
+    pub fn VirtualFree(lpAddress: *mut c_void, dwSize: size_t, dwFreeType: u32) -> u32;
+
+    pub fn CreateFileMappingA(
+        hFile: RawHandle,                       // HANDLE
+        lpFileMappingAttributes: *const c_void, // LPSECURITY_ATTRIBUTES
+        flProtect: u32,                         // DWORD
+        dwMaximumSizeHigh: u32,                 // DWORD
+        dwMaximumSizeLow: u32,                  // DWORD
+        lpName: *const u8,                      // LPCSTR
+    ) -> RawHandle; // HANDLE
+
+    pub fn MapViewOfFile(
+        hFileMappingObject: RawHandle,
+        dwDesiredAccess: u32,
+        dwFileOffsetHigh: u32,
+        dwFileOffsetLow: u32,
+        dwNumberOfBytesToMap: size_t,
+    ) -> *mut c_void;
+
+    pub fn CloseHandle(hObject: RawHandle) -> u32; // BOOL
+}
+
+pub type RawFd = std::os::windows::io::RawHandle;
+pub trait AsRawFd {
+    fn as_raw_fd(&self) -> RawFd;
+}
+
+impl AsRawFd for std::fs::File {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle()
+    }
+}
+
+const MEM_COMMIT: u32 = 0x00001000;
+const MEM_RELEASE: u32 = 0x00008000;
+const FILE_MAP_ALL_ACCESS: u32 = 0xf001f;
+const PAGE_READWRITE: u32 = 0x04;
+
+pub const MAP_FAILED: *mut c_void = 0 as *mut c_void;
+pub const INVALID_HANDLE: RawHandle = (-1isize) as RawHandle;
+
+pub unsafe fn map_anon_mem(size: usize) -> *mut c_void {
+    return VirtualAlloc(0 as *mut c_void, size, MEM_COMMIT, PAGE_READWRITE);
+}
+
+pub unsafe fn map_shared_mem(file: &AsRawFd, size: usize, offset: usize) -> *mut c_void {
+    let handle = file.as_raw_fd();
+    if handle == INVALID_HANDLE {
+        return MAP_FAILED;
+    }
+    let mapping = CreateFileMappingA(
+        handle,
+        null(),
+        PAGE_READWRITE,
+        (size >> 32) as u32,
+        size as u32,
+        null(),
+    );
+    if mapping == 0 as RawHandle {
+        return MAP_FAILED;
+    }
+    let view = MapViewOfFile(
+        mapping,
+        FILE_MAP_ALL_ACCESS,
+        (offset >> 32) as u32,
+        offset as u32,
+        size,
+    );
+    CloseHandle(mapping);
+    return view;
+}
+
+pub unsafe fn unmap_mem(addr: *mut c_void, size: usize) -> i32 {
+    if VirtualFree(addr, size, MEM_RELEASE) != 0 {
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+pub unsafe fn release_mem(addr: *mut c_void, size: usize) {
+    VirtualFree(addr, size, MEM_RELEASE);
+}

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -45,13 +45,13 @@ extern "stdcall" {
     pub fn CloseHandle(hObject: RawHandle) -> u32; // BOOL
 }
 
-pub type RawFd = std::os::windows::io::RawHandle;
-pub trait AsRawFd {
-    fn as_raw_fd(&self) -> RawFd;
+pub type RawFile = std::os::windows::io::RawHandle;
+pub trait AsRawFile {
+    fn as_raw_file(&self) -> RawFile;
 }
 
-impl AsRawFd for std::fs::File {
-    fn as_raw_fd(&self) -> RawFd {
+impl AsRawFile for std::fs::File {
+    fn as_raw_file(&self) -> RawFile {
         self.as_raw_handle()
     }
 }
@@ -68,8 +68,8 @@ pub unsafe fn map_anon_mem(size: usize) -> *mut c_void {
     return VirtualAlloc(0 as *mut c_void, size, MEM_COMMIT, PAGE_READWRITE);
 }
 
-pub unsafe fn map_shared_mem(file: &AsRawFd, size: usize, offset: usize) -> *mut c_void {
-    let handle = file.as_raw_fd();
+pub unsafe fn map_shared_mem(file: &AsRawFile, size: usize, offset: usize) -> *mut c_void {
+    let handle = file.as_raw_file();
     if handle == INVALID_HANDLE {
         return MAP_FAILED;
     }


### PR DESCRIPTION
This PR contains changes to make the crate work on Windows.

* Split out unix specific system-calls into mmap-unix
* Implement the same functionality for Windows in mmap-windows
* Fix OS specific tests
* Add (As)RawFile as an abstraction for (As)RawFd / (As)RawHandle (optional, but IMO worth doing for clarity)

I noticed that there is a new v2 branch, which has some refactoring going on. If preferred, I can rebase this on top of that branch.
